### PR TITLE
Add support to start karate in Repository directory with specified Path

### DIFF
--- a/examples/project/feature1.feature
+++ b/examples/project/feature1.feature
@@ -1,0 +1,6 @@
+Feature: Testing the Chuck Norris Joke API - part 1
+
+  Scenario: Testing random jokes GET endpoint
+    Given url 'https://api.chucknorris.io/jokes/random/'
+    When method GET
+    Then status 200

--- a/examples/project/feature2.feature
+++ b/examples/project/feature2.feature
@@ -1,0 +1,8 @@
+Feature: Testing the Chuck Norris Joke API - part 2
+
+  Scenario: Testing random career jokes GET endpoint
+    Given url 'https://api.chucknorris.io/jokes/random/'
+    And param category = 'career'
+    When method GET
+    Then status 200
+    And match response contains { categories: ["career"] }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -54,6 +54,9 @@ func (r *KarateRunner) Run(execution testkube.Execution) (result testkube.Execut
 		args = append(args, "test-content.feature")
 	} else if karateType == PROJECT_TYPE && execution.Content.IsDir() {
 		directory = filepath.Join(r.params.Datadir, "repo")
+		if execution.Content.Repository != nil && len(execution.Content.Repository.Path) > 0 {
+			directory = filepath.Join(directory, execution.Content.Repository.Path)
+		}
 		// feature file needs to be part of args
 	} else {
 		return result.Err(fmt.Errorf("unsupported content for test type %s", execution.TestType)), nil

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -1,7 +1,6 @@
 package runner
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -48,16 +47,93 @@ func TestRun(t *testing.T) {
 		assert.Equal(t, result.Status, testkube.ExecutionStatusFailed)
 		assert.Len(t, result.Steps, 1)
 	})
+
+	t.Run("project Karate test without repo path", func(t *testing.T) {
+		// given
+		runner := NewRunner()
+		execution := testkube.NewQueuedExecution()
+		repository := testkube.NewGitRepository("http://not-used/", "main")
+		execution.Content = &testkube.TestContent{Type_: "git-dir", Repository: repository}
+		execution.TestType = "karate/project"
+		execution.Args = []string{"."} // tell karate to look for features in start dir
+		writeTestContentProject(t, execution.Content.Repository, tempDir, "../../examples/project")
+
+		// when
+		result, err := runner.Run(*execution)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, result.Status, testkube.ExecutionStatusPassed)
+		assert.Len(t, result.Steps, 2)
+	})
+
+	t.Run("project Karate test with repo path", func(t *testing.T) {
+		// given
+		runner := NewRunner()
+		execution := testkube.NewQueuedExecution()
+		repository := testkube.NewGitRepository("http://not-used/", "main").WithPath("my-dir")
+		execution.Content = &testkube.TestContent{Type_: "git-dir", Repository: repository}
+		execution.TestType = "karate/project"
+		execution.Args = []string{"."} // tell karate to look for features in start dir
+		writeTestContentProject(t, execution.Content.Repository, tempDir, "../../examples/project")
+
+		// when
+		result, err := runner.Run(*execution)
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, result.Status, testkube.ExecutionStatusPassed)
+		assert.Len(t, result.Steps, 2)
+	})
 }
 
 func writeTestContent(t *testing.T, dir string, file string) {
-	featureFile, err := ioutil.ReadFile(file)
+	featureFile, err := os.ReadFile(file)
 	if err != nil {
 		assert.FailNow(t, "Unable to read Karate feature file")
 	}
 
-	err = ioutil.WriteFile(filepath.Join(dir, "test-content"), featureFile, 0644)
+	err = os.WriteFile(filepath.Join(dir, "test-content"), featureFile, 0644)
 	if err != nil {
 		assert.FailNow(t, "Unable to write Karate feature file as test content")
+	}
+}
+
+func writeTestContentProject(t *testing.T, repo *testkube.Repository, targetDir string, sourceDir string) {
+
+	repoDir := filepath.Join(targetDir, "repo")
+	if len(repo.Path) > 0 {
+		repoDir = filepath.Join(repoDir, repo.Path)
+	}
+
+	err := os.RemoveAll(repoDir)
+	if err != nil {
+		assert.FailNow(t, "Unable to clear repoDir")
+	}
+
+	_, err = os.Stat(repoDir)
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(repoDir, 0777)
+		if err != nil {
+			assert.FailNow(t, "Unable to create repoDir")
+		}
+	}
+
+	files, err := os.ReadDir(sourceDir)
+	if err != nil {
+		assert.FailNow(t, "Unable to read sourceDir")
+	}
+	for _, f := range files {
+		if !f.IsDir() {
+			file := filepath.Join(sourceDir, f.Name())
+			featureFile, err := os.ReadFile(file)
+			if err != nil {
+				assert.FailNow(t, "Unable to read Karate feature file")
+			}
+
+			err = os.WriteFile(filepath.Join(repoDir, f.Name()), featureFile, 0644)
+			if err != nil {
+				assert.FailNow(t, "Unable to write Karate feature file as test content")
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Pull request description 
We are using karate for our tests and have multiple feature files in in specific directory. This directory also contains the `karate-config.js` with the current version it was very hard to get karate working for our process. That's why I created this PR to be able to start the karate executable from the Repository.Path.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes
none
