### PR TITLE
Add standalone karate test type

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -21,13 +21,9 @@ jobs:
       - name: Build
         run: go build -v ./...
 
-      - name: Setup JBang
-        run: |
-          make install-jbang
-          echo "$HOME/.jbang/bin" >> $GITHUB_PATH
-
       - name: Setup Karate
-        run: make install-karate
+        run: |
+          make install-karate
 
       - name: Test
         run: go test -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ bin/
 site
 dist/
 target/
+/karate.jar

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME ?= testkube-karate-executor
 BIN_DIR ?= $(HOME)/bin
 NAMESPACE ?= "default"
-KARATE_VERSION ?= "1.3.1"
+KARATE_VERSION ?= 1.3.1
 
 build:
 	go build -o $(BIN_DIR)/$(NAME) cmd/agent/main.go 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 NAME ?= testkube-karate-executor
 BIN_DIR ?= $(HOME)/bin
 NAMESPACE ?= "default"
+KARATE_VERSION ?= "1.3.1"
 
 build:
 	go build -o $(BIN_DIR)/$(NAME) cmd/agent/main.go 
@@ -16,16 +17,10 @@ mongo-dev:
 docker-build: 
 	docker build -t lreimer/$(NAME) -f build/agent/Dockerfile .
 
-install-jbang:
-	curl -Ls https://sh.jbang.dev | bash -s - app setup
-
-install-jbang-mac:
-	brew install jbangdev/tap/jbang
-
 install-karate:
-	jbang app install --force --name karate com.intuit.karate:karate-core:1.3.1:all
+	curl -Ls "https://github.com/karatelabs/karate/releases/download/v$(KARATE_VERSION)/karate-$(KARATE_VERSION).jar" --output karate.jar
 
-install-swagger-codegen-mac: 
+install-swagger-codegen-mac:
 	brew install swagger-codegen
 
 test: 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,21 @@ kubectl testkube create test --file examples/karate-success.feature --type "kara
 kubectl testkube run test --watch karate-test
 ```
 
-# Issues and enchancements
+# Test types
+
+## Feature
+Use `karate/feature` to run a [single karate feature](examples/karate-success.feature) file.
+
+## Project
+Use `karate/project` to run multiple karate feature files in one test.
+
+## Standalone
+Use `karate/standalone` to run karate tests, with full control of the java start arguments.
+> Note: karate.jar is available under `/home/karate/karate.jar`
+
+Take a look at [our example](examples/karate-standalone-test.yaml) and the [karate netty docs](https://karatelabs.github.io/karate/karate-netty/) for more information.
+
+# Issues and enhancements
 
 Please follow the main [TestKube repository](https://github.com/kubeshop/testkube) for reporting any [issues](https://github.com/kubeshop/testkube/issues) or [discussions](https://github.com/kubeshop/testkube/discussions)
 

--- a/build/agent/Dockerfile
+++ b/build/agent/Dockerfile
@@ -9,7 +9,8 @@ ENV GOOS=linux
 COPY . .
 RUN cd cmd/agent;go build -o /runner -mod mod -a .
 
-FROM adoptopenjdk/openjdk11:jdk-11.0.16.1_1-slim
+FROM adoptopenjdk/openjdk11:jdk-11.0.18_10-slim
+ARG KARATEVERSION=1.3.1
 
 RUN apt-get update && \
     apt-get -y install curl && \
@@ -19,11 +20,8 @@ RUN apt-get update && \
 USER 1001
 WORKDIR /home/karate
 
-RUN curl -Ls https://sh.jbang.dev | bash -s - app setup && \
-    export PATH="/home/karate/.jbang/bin:$PATH" && \
-    jbang app install --name karate com.intuit.karate:karate-core:1.3.1:all && \
-    karate -h
+RUN curl -Ls "https://github.com/karatelabs/karate/releases/download/v$KARATEVERSION/karate-$KARATEVERSION.jar" --output karate.jar && \
+    java -jar karate.jar -h
 
-ENV PATH="/home/karate/.jbang/bin:$PATH"
 COPY --from=0 /runner /bin/runner
 ENTRYPOINT ["/bin/runner"]

--- a/examples/karate-executor.yaml
+++ b/examples/karate-executor.yaml
@@ -6,9 +6,11 @@ metadata:
 spec:
   executor_type: job
   # image: lreimer/testkube-karate-executor:main
+  # image: viyacr.azurecr.io/testkube-karate-executor:0.0.4-alpha
   image: ghcr.io/lreimer/testkube-executor-karate:main
   types:
   - karate/feature
   - karate/project
+  - karate/standalone
   features:
     - artifacts

--- a/examples/karate-standalone-test.yaml
+++ b/examples/karate-standalone-test.yaml
@@ -1,0 +1,24 @@
+apiVersion: tests.testkube.io/v3
+kind: Test
+metadata:
+  name: karate-standalone-example
+  namespace: testkube
+spec:
+  type: karate/standalone
+  content:
+    type: git-dir
+    repository:
+      type: git
+      uri: https://github.com/lreimer/testkube-executor-karate.git
+      branch: main
+      path: examples
+  executionContext:
+    args:
+      - "-cp"
+      - "/home/karate/karate.jar" # note: this is the path to karate.jar in the docker container
+      - "com.intuit.karate.Main"
+      - "-f"
+      - "junit:xml"
+      - "--tags"
+      - "~@ignore"
+      - "project"

--- a/examples/project/feature1.feature
+++ b/examples/project/feature1.feature
@@ -4,3 +4,9 @@ Feature: Testing the Chuck Norris Joke API - part 1
     Given url 'https://api.chucknorris.io/jokes/random/'
     When method GET
     Then status 200
+
+  @ignore
+  Scenario: This should be ignored
+      Given url 'https://api.chucknorris.io/jokes/random/'
+      When method GET
+      Then status 404

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -20,6 +20,10 @@ type Params struct {
 	Datadir string // RUNNER_DATADIR
 }
 
+var (
+	KarateJarPath = "/home/karate/karate.jar"
+)
+
 func NewRunner() *KarateRunner {
 	return &KarateRunner{
 		params: Params{
@@ -44,7 +48,7 @@ func (r *KarateRunner) Run(execution testkube.Execution) (result testkube.Execut
 	}
 
 	// prepare the arguments, always use JUnit XML report
-	args := []string{"-jar", "/home/karate/karate.jar", "-f", "junit:xml"}
+	args := []string{"-jar", KarateJarPath, "-f", "junit:xml"}
 	args = append(args, execution.Args...)
 
 	var directory string

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -1,23 +1,32 @@
 package runner
 
 import (
+	"fmt"
+	"github.com/kubeshop/testkube/pkg/executor/secret"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/stretchr/testify/assert"
 )
 
+type executorCallArgs struct {
+	dir       string
+	command   string
+	arguments []string
+}
+
 func TestRun(t *testing.T) {
 	// setup
+	setupKarateJar(t)
+
 	tempDir := os.TempDir()
 	os.Setenv("RUNNER_DATADIR", tempDir)
 
 	t.Run("basic Karate test feature", func(t *testing.T) {
 		// given
-		setupKarateJar(t)
-
 		runner := NewRunner()
 		execution := testkube.NewQueuedExecution()
 		execution.Content = testkube.NewStringTestContent("")
@@ -29,14 +38,12 @@ func TestRun(t *testing.T) {
 
 		// then
 		assert.NoError(t, err)
-		assert.Equal(t, result.Status, testkube.ExecutionStatusPassed)
+		assert.Equal(t, testkube.ExecutionStatusPassed, result.Status)
 		assert.Len(t, result.Steps, 2)
 	})
 
 	t.Run("basic Karate failure feature", func(t *testing.T) {
 		// given
-		setupKarateJar(t)
-
 		runner := NewRunner()
 		execution := testkube.NewQueuedExecution()
 		execution.Content = testkube.NewStringTestContent("")
@@ -48,14 +55,12 @@ func TestRun(t *testing.T) {
 
 		// then
 		assert.NoError(t, err)
-		assert.Equal(t, result.Status, testkube.ExecutionStatusFailed)
+		assert.Equal(t, testkube.ExecutionStatusFailed, result.Status)
 		assert.Len(t, result.Steps, 1)
 	})
 
 	t.Run("project Karate test without repo path", func(t *testing.T) {
 		// given
-		setupKarateJar(t)
-
 		runner := NewRunner()
 		execution := testkube.NewQueuedExecution()
 		repository := testkube.NewGitRepository("http://not-used/", "main")
@@ -75,8 +80,6 @@ func TestRun(t *testing.T) {
 
 	t.Run("project Karate test with repo path", func(t *testing.T) {
 		// given
-		setupKarateJar(t)
-
 		runner := NewRunner()
 		execution := testkube.NewQueuedExecution()
 		repository := testkube.NewGitRepository("http://not-used/", "main").WithPath("my-dir")
@@ -94,12 +97,97 @@ func TestRun(t *testing.T) {
 	})
 }
 
+func TestExecutorRunCall(t *testing.T) {
+	// setup
+	tempDir := os.TempDir()
+	os.Setenv("RUNNER_DATADIR", tempDir)
+	karateJarPath = "/home/karate/karate.jar"
+	repoContent := &testkube.TestContent{Type_: "git-dir", Repository: testkube.NewGitRepository("http://not-used", "main")}
+	repoWithPathContent := &testkube.TestContent{Type_: "git-dir", Repository: testkube.NewGitRepository("http://not-used", "main").WithPath("my-path")}
+
+	tests := []struct {
+		name          string
+		execution     *testkube.Execution
+		expectedArgs  []string
+		expectedPath  string
+		expectedError string
+	}{
+		{
+			name:         "feature uses default args",
+			execution:    newExecution("karate/feature", testkube.NewStringTestContent("")),
+			expectedArgs: []string{"-jar", "/home/karate/karate.jar", "-f", "junit:xml", "test-content.feature"},
+		},
+		{
+			name:         "project uses default args",
+			execution:    newExecution("karate/project", repoContent, "."),
+			expectedArgs: []string{"-jar", "/home/karate/karate.jar", "-f", "junit:xml", "."},
+		},
+		{
+			name:         "project start execution in repo path when specified",
+			execution:    newExecution("karate/project", repoWithPathContent, "features"),
+			expectedArgs: []string{"-jar", "/home/karate/karate.jar", "-f", "junit:xml", "features"},
+			expectedPath: repoWithPathContent.Repository.Path,
+		},
+		{
+			name:         "standalone uses only specified args",
+			execution:    newExecution("karate/standalone", repoContent, "-Dsomeurl=https://google.com", "-cp", "/home/karate/karate.jar", "com.intuit.karate.Main", "-f", "junit:xml", "my-path"),
+			expectedArgs: []string{"-Dsomeurl=https://google.com", "-cp", "/home/karate/karate.jar", "com.intuit.karate.Main", "-f", "junit:xml", "my-path"},
+		},
+		{
+			name:          "standalone throws error on missing args",
+			execution:     newExecution("karate/standalone", repoContent),
+			expectedError: "args are required for test type karate/standalone",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// given
+			var actualCall executorCallArgs
+			executorRun = func(dir string, command string, envMngr secret.Manager, arguments ...string) (out []byte, err error) {
+				actualCall = executorCallArgs{
+					dir:       dir,
+					command:   command,
+					arguments: arguments,
+				}
+				return []byte{}, fmt.Errorf("only interested in executor call")
+			}
+
+			// when
+			result, err := NewRunner().Run(*tt.execution)
+
+			// then
+			assert.NoError(t, err)
+			if len(tt.expectedError) > 0 {
+				assert.Equal(t, tt.expectedError, result.ErrorMessage)
+				return
+			}
+			assert.Equal(t, testkube.ExecutionStatusFailed, result.Status)
+			assert.NotNil(t, actualCall)
+
+			if len(tt.expectedPath) > 0 {
+				assert.True(t, strings.HasSuffix(actualCall.dir, tt.expectedPath))
+			}
+			assert.Equal(t, "java", actualCall.command)
+			assert.Equal(t, tt.expectedArgs, actualCall.arguments)
+		})
+	}
+}
+
+func newExecution(testType string, content *testkube.TestContent, arguments ...string) *testkube.Execution {
+	execution := testkube.NewQueuedExecution()
+	execution.TestType = testType
+	execution.Content = content
+	execution.Args = arguments
+	return execution
+}
+
 func setupKarateJar(t *testing.T) {
 	localJar, err := filepath.Abs("../../karate.jar")
 	if err != nil {
 		assert.FailNow(t, "can't locate karate.jar, please run `make install-karate`")
 	}
-	KarateJarPath = localJar
+	karateJarPath = localJar
 }
 
 func writeTestContent(t *testing.T, dir string, file string) {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -16,6 +16,8 @@ func TestRun(t *testing.T) {
 
 	t.Run("basic Karate test feature", func(t *testing.T) {
 		// given
+		setupKarateJar(t)
+
 		runner := NewRunner()
 		execution := testkube.NewQueuedExecution()
 		execution.Content = testkube.NewStringTestContent("")
@@ -33,6 +35,8 @@ func TestRun(t *testing.T) {
 
 	t.Run("basic Karate failure feature", func(t *testing.T) {
 		// given
+		setupKarateJar(t)
+
 		runner := NewRunner()
 		execution := testkube.NewQueuedExecution()
 		execution.Content = testkube.NewStringTestContent("")
@@ -50,6 +54,8 @@ func TestRun(t *testing.T) {
 
 	t.Run("project Karate test without repo path", func(t *testing.T) {
 		// given
+		setupKarateJar(t)
+
 		runner := NewRunner()
 		execution := testkube.NewQueuedExecution()
 		repository := testkube.NewGitRepository("http://not-used/", "main")
@@ -69,6 +75,8 @@ func TestRun(t *testing.T) {
 
 	t.Run("project Karate test with repo path", func(t *testing.T) {
 		// given
+		setupKarateJar(t)
+
 		runner := NewRunner()
 		execution := testkube.NewQueuedExecution()
 		repository := testkube.NewGitRepository("http://not-used/", "main").WithPath("my-dir")
@@ -84,6 +92,14 @@ func TestRun(t *testing.T) {
 		assert.Equal(t, result.Status, testkube.ExecutionStatusPassed)
 		assert.Len(t, result.Steps, 2)
 	})
+}
+
+func setupKarateJar(t *testing.T) {
+	localJar, err := filepath.Abs("../../karate.jar")
+	if err != nil {
+		assert.FailNow(t, "can't locate karate.jar, please run `make install-karate`")
+	}
+	KarateJarPath = localJar
 }
 
 func writeTestContent(t *testing.T, dir string, file string) {


### PR DESCRIPTION
## Pull request description 
By providing support for the standalone karate jar, the executor becomes more flexible.

This provides a way for users to support class path execution of java and use custom karate hooks located in another jar.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [x] added a test

## Breaking changes
none

## Changes
- Removed the jbang dependency
- Updated JDK to 11.0.18_10

## Fixes
Some comments in the code